### PR TITLE
Prevent spurious divide by zero warnings that typically occur early in portfolio backtesting

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -707,6 +707,7 @@ def sharpe_ratio(
             nanmean(returns_risk_adj, axis=0),
             nanstd(returns_risk_adj, ddof=1, axis=0),
             out=out,
+            where=nanstd(returns_risk_adj, ddof=1, axis=0) != 0
         ),
         np.sqrt(ann_factor),
         out=out,
@@ -794,7 +795,10 @@ def sortino_ratio(
         if _downside_risk is not None
         else downside_risk(returns, required_return, period, annualization)
     )
-    np.divide(average_annual_return, annualized_downside_risk, out=out)
+    np.divide(average_annual_return, 
+              annualized_downside_risk, 
+              out=out,
+              where=annualized_downside_risk!=0)
     if return_1d:
         out = out.item()
     elif isinstance(returns, pd.DataFrame):


### PR DESCRIPTION
Empyircal provides various warnings when during normal operationals, typically when there are no positions in a portfolio or the portfolio value has not changed.

Examples include:
empyrical\stats.py:710: RuntimeWarning: invalid value encountered in true_divide
and
empyrical\stats.py:799: RuntimeWarning: invalid value encountered in true_divide

This PR simply bypasses those calculations on those dates with negligible overhead.
