### PR TITLE
Tests and stats.py refactoring 

### DIFF
--- a/empyrical/__init__.py
+++ b/empyrical/__init__.py
@@ -66,6 +66,7 @@ from .stats import (
     up_alpha_beta,
     up_capture,
     up_down_capture,
+    batting_average,
     value_at_risk,
 )
 

--- a/empyrical/__init__.py
+++ b/empyrical/__init__.py
@@ -48,7 +48,6 @@ from .stats import (
     roll_alpha,
     roll_alpha_aligned,
     roll_alpha_beta,
-    roll_alpha_beta,
     roll_alpha_beta_aligned,
     roll_annual_volatility,
     roll_beta,

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -36,6 +36,8 @@ from .utils import (
 from .periods import ANNUALIZATION_FACTORS, APPROX_BDAYS_PER_YEAR
 from .periods import DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY
 
+import warnings
+
 
 def annualization_factor(period, annualization):
     """
@@ -647,6 +649,11 @@ def sharpe_ratio(
     returns_risk_adj = np.asanyarray(_adjust_returns(returns, risk_free))
     ann_factor = annualization_factor(period, annualization)
 
+    warnings.filterwarnings(
+        "ignore",
+        category=RuntimeWarning,
+        message="divide by zero",
+    )
     np.multiply(
         np.divide(
             nanmean(returns_risk_adj, axis=0),

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -480,15 +480,6 @@ roll_annual_volatility = _create_unary_vectorized_roll_function(
 )
 
 
-def ulcer_index(returns):
-    dd = drawdown_series(returns)
-    return np.power(np.divide(np.power(dd, 2).sum(), len(dd)), 0.5)
-
-
-def pain_index():
-    pass
-
-
 def calmar_ratio(returns, period=DAILY, annualization=None):
     """
     Determines the Calmar ratio, or drawdown ratio, of a strategy.
@@ -1897,7 +1888,27 @@ def up_down_capture(returns, factor_returns, **kwargs):
     )
 
 
-def batting_average(returns, factor_returns, **kwargs):
+def batting_average(returns, factor_returns):
+    """
+    Computes the batting average.
+    Parameters
+    ----------
+    returns : pd.Series or np.ndarray
+        Returns of the strategy, noncumulative.
+        - See full explanation in :func:`~empyrical.stats.cum_returns`.
+    factor_returns : pd.Series or np.ndarray
+        Noncumulative returns of the factor to which beta is
+        computed. Usually a benchmark such as the market.
+        - This is in the same style as returns.
+    Returns
+    -------
+    batting_average : pd.Series
+        batting average, up market, down market
+    Note
+    ----
+    See https://www.investopedia.com/terms/b/batting-average.asp for
+    more information.
+    """
     results = OrderedDict(
         {
             "batting average": np.nan,
@@ -1907,8 +1918,8 @@ def batting_average(returns, factor_returns, **kwargs):
     )
     active_return = _adjust_returns(returns, factor_returns)
     bt = active_return > 0
-    up = active_return[factor_returns >= 0.0]
-    down = active_return[factor_returns < 0.0]
+    up = active_return[factor_returns >= 0.0] > 0
+    down = active_return[factor_returns < 0.0] > 0
     if len(bt) > 0:
         results["batting average"] = bt.mean()
     if len(up) > 0:

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -14,137 +14,27 @@
 # limitations under the License.
 
 import math
+from collections import OrderedDict
 import pandas as pd
 import numpy as np
 from math import pow
 from scipy import stats, optimize
 from sys import float_info
 
-from .utils import nanmean, nanstd, nanmin, up, down, roll, rolling_window
+from .utils import (
+    nanmean,
+    nanstd,
+    nanmin,
+    up,
+    down,
+    roll,
+    _create_unary_vectorized_roll_function,
+    _create_binary_vectorized_roll_function,
+    _aligned_series,
+    _adjust_returns,
+)
 from .periods import ANNUALIZATION_FACTORS, APPROX_BDAYS_PER_YEAR
 from .periods import DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY
-
-
-def _create_unary_vectorized_roll_function(function):
-    def unary_vectorized_roll(arr, window, out=None, **kwargs):
-        """
-        Computes the {human_readable} measure over a rolling window.
-
-        Parameters
-        ----------
-        arr : array-like
-            The array to compute the rolling {human_readable} over.
-        window : int
-            Size of the rolling window in terms of the periodicity of the data.
-        out : array-like, optional
-            Array to use as output buffer.
-            If not passed, a new array will be created.
-        **kwargs
-            Forwarded to :func:`~empyrical.{name}`.
-
-        Returns
-        -------
-        rolling_{name} : array-like
-            The rolling {human_readable}.
-        """
-        allocated_output = out is None
-
-        if len(arr):
-            out = function(
-                rolling_window(_flatten(arr), min(len(arr), window)).T,
-                out=out,
-                **kwargs,
-            )
-        else:
-            out = np.empty(0, dtype="float64")
-
-        if allocated_output and isinstance(arr, pd.Series):
-            out = pd.Series(out, index=arr.index[-len(out) :])
-
-        return out
-
-    unary_vectorized_roll.__doc__ = unary_vectorized_roll.__doc__.format(
-        name=function.__name__,
-        human_readable=function.__name__.replace("_", " "),
-    )
-
-    return unary_vectorized_roll
-
-
-def _create_binary_vectorized_roll_function(function):
-    def binary_vectorized_roll(lhs, rhs, window, out=None, **kwargs):
-        """
-        Computes the {human_readable} measure over a rolling window.
-
-        Parameters
-        ----------
-        lhs : array-like
-            The first array to pass to the rolling {human_readable}.
-        rhs : array-like
-            The second array to pass to the rolling {human_readable}.
-        window : int
-            Size of the rolling window in terms of the periodicity of the data.
-        out : array-like, optional
-            Array to use as output buffer.
-            If not passed, a new array will be created.
-        **kwargs
-            Forwarded to :func:`~empyrical.{name}`.
-
-        Returns
-        -------
-        rolling_{name} : array-like
-            The rolling {human_readable}.
-        """
-        allocated_output = out is None
-
-        if window >= 1 and len(lhs) and len(rhs):
-            out = function(
-                rolling_window(_flatten(lhs), min(len(lhs), window)).T,
-                rolling_window(_flatten(rhs), min(len(rhs), window)).T,
-                out=out,
-                **kwargs,
-            )
-        elif allocated_output:
-            out = np.empty(0, dtype="float64")
-        else:
-            out[()] = np.nan
-
-        if allocated_output:
-            if out.ndim == 1 and isinstance(lhs, pd.Series):
-                out = pd.Series(out, index=lhs.index[-len(out) :])
-            elif out.ndim == 2 and isinstance(lhs, pd.Series):
-                out = pd.DataFrame(out, index=lhs.index[-len(out) :])
-        return out
-
-    binary_vectorized_roll.__doc__ = binary_vectorized_roll.__doc__.format(
-        name=function.__name__,
-        human_readable=function.__name__.replace("_", " "),
-    )
-
-    return binary_vectorized_roll
-
-
-def _flatten(arr):
-    return arr if not isinstance(arr, pd.Series) else arr.values
-
-
-def _adjust_returns(returns, adjustment_factor):
-    """
-    Returns the returns series adjusted by adjustment_factor. Optimizes for the
-    case of adjustment_factor being 0 by returning returns itself, not a copy!
-
-    Parameters
-    ----------
-    returns : pd.Series or np.ndarray
-    adjustment_factor : pd.Series or np.ndarray or float or int
-
-    Returns
-    -------
-    adjusted_returns : array-like
-    """
-    if isinstance(adjustment_factor, (float, int)) and adjustment_factor == 0:
-        return returns
-    return returns - adjustment_factor
 
 
 def annualization_factor(period, annualization):
@@ -348,6 +238,63 @@ def aggregate_returns(returns, convert_to):
     return returns.groupby(grouping).apply(cumulate_returns)
 
 
+def drawdown_series(returns, out=None):
+    """
+    Computes the series of drawdowns of a strategy.
+
+    Parameters
+    ----------
+    returns : pd.Series, pd.DataFrame or np.ndarray
+        Daily returns of the strategy, noncumulative.
+        - See full explanation in :func:`~empyrical.stats.cum_returns`.
+    out : array-like, optional
+        Array to use as output buffer.
+        If not passed, a new array will be created.
+
+    Returns
+    -------
+    drawdown_series :  pd.Series, pd.DataFrame or np.ndarray
+
+    Note
+    -----
+    See https://en.wikipedia.org/wiki/Drawdown_(economics) for more details.
+    """
+    allocated_output = out is None
+    if allocated_output:
+        out = np.empty(
+            (returns.shape[0] + 1,) + returns.shape[1:],
+            dtype="float64",
+        )
+
+    returns_1d = returns.ndim == 1
+
+    if len(returns) < 1:
+        out[()] = np.nan
+        if returns_1d:
+            out = out.item()
+        return out
+
+    returns_array = np.asanyarray(returns)
+
+    out[0] = start = 100
+    cum_returns(returns_array, starting_value=start, out=out[1:])
+
+    max_return = np.fmax.accumulate(out, axis=0)
+
+    np.divide((out - max_return), max_return, out=out)
+
+    if returns.ndim == 1 and isinstance(returns, pd.Series):
+        out = pd.Series(out[1:], index=returns.index)
+    elif isinstance(returns, pd.DataFrame):
+        out = pd.DataFrame(
+            out[1:],
+            index=returns.index,
+            columns=returns.columns,
+        )
+
+    return out
+
+
 def max_drawdown(returns, out=None):
     """
     Determines the maximum drawdown of a strategy.
@@ -363,7 +310,7 @@ def max_drawdown(returns, out=None):
 
     Returns
     -------
-    max_drawdown : float
+    max_drawdown : float, np.array or pd.Series
 
     Note
     -----
@@ -381,22 +328,11 @@ def max_drawdown(returns, out=None):
             out = out.item()
         return out
 
-    returns_array = np.asanyarray(returns)
-
-    cumulative = np.empty(
-        (returns.shape[0] + 1,) + returns.shape[1:],
-        dtype="float64",
-    )
-    cumulative[0] = start = 100
-    cum_returns(returns_array, starting_value=start, out=cumulative[1:])
-
-    max_return = np.fmax.accumulate(cumulative, axis=0)
-
-    nanmin((cumulative - max_return) / max_return, axis=0, out=out)
+    nanmin(drawdown_series(returns), axis=0, out=out)
     if returns_1d:
         out = out.item()
     elif allocated_output and isinstance(returns, pd.DataFrame):
-        out = pd.Series(out)
+        out = pd.Series(out, index=returns.columns)
 
     return out
 
@@ -540,6 +476,15 @@ def annual_volatility(
 roll_annual_volatility = _create_unary_vectorized_roll_function(
     annual_volatility,
 )
+
+
+def ulcer_index(returns):
+    dd = drawdown_series(returns)
+    return np.power(np.divide(np.power(dd, 2).sum(), len(dd)), 0.5)
+
+
+def pain_index():
+    pass
 
 
 def calmar_ratio(returns, period=DAILY, annualization=None):
@@ -937,64 +882,6 @@ def excess_sharpe(returns, factor_returns, out=None):
 
 
 roll_excess_sharpe = _create_binary_vectorized_roll_function(excess_sharpe)
-
-
-def _to_pandas(ob):
-    """Convert an array-like to a pandas object.
-
-    Parameters
-    ----------
-    ob : array-like
-        The object to convert.
-
-    Returns
-    -------
-    pandas_structure : pd.Series or pd.DataFrame
-        The correct structure based on the dimensionality of the data.
-    """
-    if isinstance(ob, (pd.Series, pd.DataFrame)):
-        return ob
-
-    if ob.ndim == 1:
-        return pd.Series(ob)
-    elif ob.ndim == 2:
-        return pd.DataFrame(ob)
-    else:
-        raise ValueError(
-            "cannot convert array of dim > 2 to a pandas structure",
-        )
-
-
-def _aligned_series(*many_series):
-    """
-    Return a new list of series containing the data in the input series, but
-    with their indices aligned. NaNs will be filled in for missing values.
-
-    Parameters
-    ----------
-    *many_series
-        The series to align.
-
-    Returns
-    -------
-    aligned_series : iterable[array-like]
-        A new list of series containing the data in the input series, but
-        with their indices aligned. NaNs will be filled in for missing values.
-
-    """
-    head = many_series[0]
-    tail = many_series[1:]
-    n = len(head)
-    if isinstance(head, np.ndarray) and all(
-        len(s) == n and isinstance(s, np.ndarray) for s in tail
-    ):
-        # optimization: ndarrays of the same length are already aligned
-        return many_series
-
-    # dataframe has no ``itervalues``
-    return (
-        v for _, v in pd.concat(map(_to_pandas, many_series), axis=1).items()
-    )
 
 
 def alpha_beta(
@@ -2001,6 +1888,28 @@ def up_down_capture(returns, factor_returns, **kwargs):
     return up_capture(returns, factor_returns, **kwargs) / down_capture(
         returns, factor_returns, **kwargs
     )
+
+
+def batting_average(returns, factor_returns, **kwargs):
+    results = OrderedDict(
+        {
+            "batting average": np.nan,
+            "up market": np.nan,
+            "down market": np.nan,
+        }
+    )
+    active_return = _adjust_returns(returns, factor_returns)
+    bt = active_return > 0
+    up = active_return[factor_returns >= 0.0]
+    down = active_return[factor_returns < 0.0]
+    if len(bt) > 0:
+        results["batting average"] = bt.mean()
+    if len(up) > 0:
+        results["up market"] = up.mean()
+    if len(down) > 0:
+        results["down market"] = down.mean()
+
+    return pd.Series(results, index=results.keys())
 
 
 def up_alpha_beta(returns, factor_returns, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,8 +170,6 @@ def input_data():
         ),
         # Positive and negative returns with max drawdown
         "mixed_returns": mixed_returns,
-        # Flat line
-        "flat_line_1": flat_line_1_tz,
         # Weekly returns
         "weekly_returns": pd.Series(
             np.array([0.0, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
@@ -312,7 +310,7 @@ def expected_data():
         106.646123,
     ]
 
-    mixed_returns_expected_gpd_risk_result = [
+    mixed_returns_gpd_risk = [
         0.1,
         0.10001255835838491,
         1.5657360018514067e-06,
@@ -320,7 +318,7 @@ def expected_data():
         0.59126595492541179,
     ]
 
-    negative_returns_expected_gpd_risk_result = [
+    negative_returns_gpd_risk = [
         0.05,
         0.068353586736348199,
         9.4304947982121171e-07,
@@ -347,8 +345,8 @@ def expected_data():
         "df_empty": pd.DataFrame(),
         "df_0_expected": df_0_expected,
         "df_100_expected": df_100_expected,
-        "mixed_returns_expected_gpd_risk_result": mixed_returns_expected_gpd_risk_result,
-        "negative_returns_expected_gpd_risk_result": negative_returns_expected_gpd_risk_result,
+        "mixed_returns_expected_gpd_risk_result": mixed_returns_gpd_risk,
+        "negative_returns_expected_gpd_risk_result": negative_returns_gpd_risk,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,360 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+
+@pytest.fixture(scope="function")
+def set_helpers(request):
+    rand = np.random.RandomState(1337)
+    request.cls.ser_length = 120
+    request.cls.window = 12
+
+    request.cls.returns = pd.Series(
+        rand.randn(1, 120)[0] / 100.0,
+        index=pd.date_range("2000-1-30", periods=120, freq="M"),
+    )
+
+    request.cls.factor_returns = pd.Series(
+        rand.randn(1, 120)[0] / 100.0,
+        index=pd.date_range("2000-1-30", periods=120, freq="M"),
+    )
+
+
+@pytest.fixture(scope="session")
+def input_data():
+    simple_benchmark = pd.Series(
+        np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]) / 100,
+        index=pd.date_range("2000-1-30", periods=9, freq="D"),
+    )
+
+    rand = np.random.RandomState(1337)
+
+    noise = pd.Series(
+        rand.normal(0, 0.001, 1000),
+        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+    )
+
+    inv_noise = noise.multiply(-1)
+
+    noise_uniform = pd.Series(
+        rand.uniform(-0.01, 0.01, 1000),
+        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+    )
+
+    random_100k = pd.Series(rand.randn(100_000))
+    mixed_returns = pd.Series(
+        np.array([np.nan, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
+        index=pd.date_range("2000-1-30", periods=9, freq="D"),
+    )
+
+    one = [
+        -0.00171614,
+        0.01322056,
+        0.03063862,
+        -0.01422057,
+        -0.00489779,
+        0.01268925,
+        -0.03357711,
+        0.01797036,
+    ]
+
+    two = [
+        0.01846232,
+        0.00793951,
+        -0.01448395,
+        0.00422537,
+        -0.00339611,
+        0.03756813,
+        0.0151531,
+        0.03549769,
+    ]
+
+    # Sparse noise, same as noise but with np.nan sprinkled in
+    replace_nan = rand.choice(noise.index.tolist(), rand.randint(1, 10))
+    sparse_noise = noise.replace(replace_nan, np.nan)
+
+    # Flat line tz
+    flat_line_1_tz = pd.Series(
+        np.linspace(0.01, 0.01, num=1000),
+        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+    )
+
+    # Sparse flat line at 0.01
+    # replace_nan = rand.choice(noise.index.tolist(), rand.randint(1, 10))
+    sparse_flat_line_1_tz = flat_line_1_tz.replace(replace_nan, np.nan)
+
+    df_index_simple = pd.date_range("2000-1-30", periods=8, freq="D")
+    df_index_week = pd.date_range("2000-1-30", periods=8, freq="W")
+    df_index_month = pd.date_range("2000-1-30", periods=8, freq="M")
+
+    df_week = pd.DataFrame(
+        {
+            "one": pd.Series(one, index=df_index_week),
+            "two": pd.Series(two, index=df_index_week),
+        }
+    )
+
+    df_month = pd.DataFrame(
+        {
+            "one": pd.Series(one, index=df_index_month),
+            "two": pd.Series(two, index=df_index_month),
+        }
+    )
+
+    df_simple = pd.DataFrame(
+        {
+            "one": pd.Series(one, index=df_index_simple),
+            "two": pd.Series(two, index=df_index_simple),
+        }
+    )
+
+    df_week = pd.DataFrame(
+        {
+            "one": pd.Series(one, index=df_index_week),
+            "two": pd.Series(two, index=df_index_week),
+        }
+    )
+
+    df_month = pd.DataFrame(
+        {
+            "one": pd.Series(one, index=df_index_month),
+            "two": pd.Series(two, index=df_index_month),
+        }
+    )
+
+    input_one = [
+        np.nan,
+        0.01322056,
+        0.03063862,
+        -0.01422057,
+        -0.00489779,
+        0.01268925,
+        -0.03357711,
+        0.01797036,
+    ]
+    input_two = [
+        0.01846232,
+        0.00793951,
+        -0.01448395,
+        0.00422537,
+        -0.00339611,
+        0.03756813,
+        0.0151531,
+        np.nan,
+    ]
+
+    df_index = pd.date_range("2000-1-30", periods=8, freq="D")
+
+    return {
+        # Simple benchmark, no drawdown
+        "simple_benchmark": simple_benchmark,
+        "simple_benchmark_w_noise": simple_benchmark
+        + rand.normal(0, 0.001, len(simple_benchmark)),
+        "simple_benchmark_df": simple_benchmark.rename("returns").to_frame(),
+        # All positive returns, small variance
+        "positive_returns": pd.Series(
+            np.array([1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="D"),
+        ),
+        # All negative returns
+        "negative_returns": pd.Series(
+            np.array([0.0, -6.0, -7.0, -1.0, -9.0, -2.0, -6.0, -8.0, -5.0])
+            / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="D"),
+        ),
+        # All negative returns
+        "all_negative_returns": pd.Series(
+            np.array([-2.0, -6.0, -7.0, -1.0, -9.0, -2.0, -6.0, -8.0, -5.0])
+            / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="D"),
+        ),
+        # Positive and negative returns with max drawdown
+        "mixed_returns": mixed_returns,
+        # Flat line
+        "flat_line_1": flat_line_1_tz,
+        # Weekly returns
+        "weekly_returns": pd.Series(
+            np.array([0.0, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="W"),
+        ),
+        # Monthly returns
+        "monthly_returns": pd.Series(
+            np.array([0.0, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="M"),
+        ),
+        # Series of length 1
+        "one_return": pd.Series(
+            np.array([1.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=1, freq="D"),
+        ),
+        "udu_returns": pd.Series(
+            np.array([10, -10, 10]) / 100,
+            index=pd.date_range("2000-1-30", periods=3, freq="D"),
+        ),
+        # Empty series
+        "empty_returns": pd.Series(
+            np.array([]) / 100,
+            index=pd.date_range("2000-1-30", periods=0, freq="D"),
+        ),
+        # Random noise
+        "noise": noise,
+        "noise_uniform": noise_uniform,
+        "random_100k": random_100k,
+        # Random noise inv
+        "inv_noise": inv_noise,
+        # Flat line
+        "flat_line_0": pd.Series(
+            np.linspace(0, 0, num=1000),
+            index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+        ),
+        "flat_line_1": pd.Series(
+            np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=9, freq="D"),
+        ),
+        # Flat line with tz
+        "flat_line_1_tz": pd.Series(
+            np.linspace(0.01, 0.01, num=1000),
+            index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+        ),
+        "flat_line_yearly": pd.Series(
+            np.array([3.0, 3.0, 3.0]) / 100,
+            index=pd.date_range("2000-1-30", periods=3, freq="A"),
+        ),
+        # Positive line
+        "pos_line": pd.Series(
+            np.linspace(0, 1, num=1000),
+            index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+        ),
+        # Negative line
+        "neg_line": pd.Series(
+            np.linspace(0, -1, num=1000),
+            index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
+        ),
+        # Sparse noise, same as noise but with np.nan sprinkled in
+        "sparse_noise": sparse_noise,
+        # Sparse flat line at 0.01
+        "sparse_flat_line_1_tz": sparse_flat_line_1_tz,
+        "one": one,
+        "two": two,
+        "df_index_simple": df_index_simple,
+        "df_index_week": df_index_week,
+        "df_index_month": df_index_month,
+        "df_simple": df_simple,
+        "df_week": df_week,
+        "df_month": df_month,
+        "df_empty": pd.DataFrame(),
+        "df_input": pd.DataFrame(
+            {
+                "one": pd.Series(input_one, index=df_index),
+                "two": pd.Series(input_two, index=df_index),
+            }
+        ),
+    }
+
+
+@pytest.fixture
+def returns(input_data, request):
+    name = request.param
+    if name not in input_data.keys():
+        return eval(name, input_data)
+    return input_data[name]
+
+
+required_return = returns
+benchmark = returns
+risk_free = returns
+factor_returns = returns
+add_noise = returns
+prices = returns
+
+
+@pytest.fixture(scope="session")
+def expected_data():
+    expected_0_one = [
+        0.000000,
+        0.013221,
+        0.044264,
+        0.029414,
+        0.024372,
+        0.037371,
+        0.002539,
+        0.020555,
+    ]
+    expected_0_two = [
+        0.018462,
+        0.026548,
+        0.011680,
+        0.015955,
+        0.012504,
+        0.050542,
+        0.066461,
+        0.066461,
+    ]
+
+    expected_100_one = [
+        100.000000,
+        101.322056,
+        104.426424,
+        102.941421,
+        102.437235,
+        103.737087,
+        100.253895,
+        102.055494,
+    ]
+    expected_100_two = [
+        101.846232,
+        102.654841,
+        101.167994,
+        101.595466,
+        101.250436,
+        105.054226,
+        106.646123,
+        106.646123,
+    ]
+
+    mixed_returns_expected_gpd_risk_result = [
+        0.1,
+        0.10001255835838491,
+        1.5657360018514067e-06,
+        0.4912526273742347,
+        0.59126595492541179,
+    ]
+
+    negative_returns_expected_gpd_risk_result = [
+        0.05,
+        0.068353586736348199,
+        9.4304947982121171e-07,
+        0.34511639904932639,
+        0.41347032855617882,
+    ]
+
+    df_index = pd.date_range("2000-1-30", periods=8, freq="D")
+
+    df_0_expected = pd.DataFrame(
+        {
+            "one": pd.Series(expected_0_one, index=df_index),
+            "two": pd.Series(expected_0_two, index=df_index),
+        }
+    )
+
+    df_100_expected = pd.DataFrame(
+        {
+            "one": pd.Series(expected_100_one, index=df_index),
+            "two": pd.Series(expected_100_two, index=df_index),
+        }
+    )
+    return {
+        "df_empty": pd.DataFrame(),
+        "df_0_expected": df_0_expected,
+        "df_100_expected": df_100_expected,
+        "mixed_returns_expected_gpd_risk_result": mixed_returns_expected_gpd_risk_result,
+        "negative_returns_expected_gpd_risk_result": negative_returns_expected_gpd_risk_result,
+    }
+
+
+@pytest.fixture
+def expected(expected_data, request):
+    name = request.param
+    if name not in expected_data.keys():
+        return eval(name)
+    return expected_data[name]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1716,6 +1716,28 @@ class Test2DStats:
         np.testing.assert_almost_equal(np.array(result), expected.iloc[-1], 5)
         self.assert_indexes_match(result, expected.iloc[-1])
 
+    @pytest.mark.parametrize(
+        "returns, benchmark, expected",
+        [
+            ("empty_returns", "empty_returns", [np.nan, np.nan, np.nan]),
+            ("positive_returns", "all_negative_returns", [1, np.nan, 1]),
+            ("all_negative_returns", "positive_returns", [0, 0, np.nan]),
+            ("mixed_returns", "mixed_returns", [0, 0, 0]),
+            (
+                "simple_benchmark",
+                "simple_benchmark_w_noise",
+                [0.666667, 0.5, 1.0],
+            ),
+        ],
+        indirect=["returns", "benchmark"],
+    )
+    def test_batting_average(self, returns, benchmark, expected):
+        return_types = (pd.Series, np.ndarray)
+        batting_average = self.empyrical(
+            return_types=return_types
+        ).batting_average(returns, benchmark)
+        np.testing.assert_almost_equal(batting_average, expected, 4)
+
     @property
     def empyrical(self):
         """

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,4 @@
 from copy import copy
-from empyrical.periods import YEARLY
 from operator import attrgetter
 
 import numpy as np

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,5 @@
 from copy import copy
+from empyrical.periods import YEARLY
 from operator import attrgetter
 
 import numpy as np
@@ -39,166 +40,15 @@ class BaseTestClass:
 
 
 class TestStats(BaseTestClass):
-
-    # Simple benchmark, no drawdown
-    simple_benchmark = pd.Series(
-        np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # All positive returns, small variance
-    positive_returns = pd.Series(
-        np.array([1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # All negative returns
-    negative_returns = pd.Series(
-        np.array([0.0, -6.0, -7.0, -1.0, -9.0, -2.0, -6.0, -8.0, -5.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # All negative returns
-    all_negative_returns = pd.Series(
-        np.array([-2.0, -6.0, -7.0, -1.0, -9.0, -2.0, -6.0, -8.0, -5.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # Positive and negative returns with max drawdown
-    mixed_returns = pd.Series(
-        np.array([np.nan, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # Flat line
-    flat_line_1 = pd.Series(
-        np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="D"),
-    )
-
-    # Weekly returns
-    weekly_returns = pd.Series(
-        np.array([0.0, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="W"),
-    )
-
-    # Monthly returns
-    monthly_returns = pd.Series(
-        np.array([0.0, 1.0, 10.0, -4.0, 2.0, 3.0, 2.0, 1.0, -10.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=9, freq="M"),
-    )
-
-    # Series of length 1
-    one_return = pd.Series(
-        np.array([1.0]) / 100,
-        index=pd.date_range("2000-1-30", periods=1, freq="D"),
-    )
-
-    # Empty series
-    empty_returns = pd.Series(
-        np.array([]) / 100,
-        index=pd.date_range("2000-1-30", periods=0, freq="D"),
-    )
-
-    # Random noise
-    noise = pd.Series(
-        rand.normal(0, 0.001, 1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-
-    noise_uniform = pd.Series(
-        rand.uniform(-0.01, 0.01, 1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-
-    # Random noise inv
-    inv_noise = noise.multiply(-1)
-
-    # Flat line
-    flat_line_0 = pd.Series(
-        np.linspace(0, 0, num=1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-    # Flat line
-    flat_line_1_tz = pd.Series(
-        np.linspace(0.01, 0.01, num=1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-
-    # Positive line
-    pos_line = pd.Series(
-        np.linspace(0, 1, num=1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-
-    # Negative line
-    neg_line = pd.Series(
-        np.linspace(0, -1, num=1000),
-        index=pd.date_range("2000-1-30", periods=1000, freq="D", tz="UTC"),
-    )
-
-    # Sparse noise, same as noise but with np.nan sprinkled in
-    replace_nan = rand.choice(noise.index.tolist(), rand.randint(1, 10))
-    sparse_noise = noise.replace(replace_nan, np.nan)
-
-    # Sparse flat line at 0.01
-    replace_nan = rand.choice(noise.index.tolist(), rand.randint(1, 10))
-    sparse_flat_line_1_tz = flat_line_1_tz.replace(replace_nan, np.nan)
-
-    one = [
-        -0.00171614,
-        0.01322056,
-        0.03063862,
-        -0.01422057,
-        -0.00489779,
-        0.01268925,
-        -0.03357711,
-        0.01797036,
-    ]
-    two = [
-        0.01846232,
-        0.00793951,
-        -0.01448395,
-        0.00422537,
-        -0.00339611,
-        0.03756813,
-        0.0151531,
-        0.03549769,
-    ]
-
-    df_index_simple = pd.date_range("2000-1-30", periods=8, freq="D")
-    df_index_week = pd.date_range("2000-1-30", periods=8, freq="W")
-    df_index_month = pd.date_range("2000-1-30", periods=8, freq="M")
-
-    df_simple = pd.DataFrame(
-        {
-            "one": pd.Series(one, index=df_index_simple),
-            "two": pd.Series(two, index=df_index_simple),
-        }
-    )
-
-    df_week = pd.DataFrame(
-        {
-            "one": pd.Series(one, index=df_index_week),
-            "two": pd.Series(two, index=df_index_week),
-        }
-    )
-
-    df_month = pd.DataFrame(
-        {
-            "one": pd.Series(one, index=df_index_month),
-            "two": pd.Series(two, index=df_index_month),
-        }
-    )
-
     @pytest.mark.parametrize(
         "prices, expected",
         [
             # Constant price implies zero returns,
             # and linearly increasing prices imples returns like 1/n
-            (flat_line_1, [0.0] * (flat_line_1.shape[0] - 1)),
-            (pos_line, [np.inf] + [1 / n for n in range(1, 999)]),
+            ("flat_line_1", [0.0] * (9 - 1)),
+            ("pos_line", [np.inf] + [1 / n for n in range(1, 999)]),
         ],
+        indirect=["prices"],
     )
     def test_simple_returns(self, prices, expected):
         simple_returns = self.empyrical.simple_returns(prices)
@@ -208,9 +58,9 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, starting_value, expected",
         [
-            (empty_returns, 0, []),
+            ("empty_returns", 0, []),
             (
-                mixed_returns,
+                "mixed_returns",
                 0,
                 [
                     0.0,
@@ -225,7 +75,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
             (
-                mixed_returns,
+                "mixed_returns",
                 100,
                 [
                     100.0,
@@ -240,7 +90,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
             (
-                negative_returns,
+                "negative_returns",
                 0,
                 [
                     0.0,
@@ -255,6 +105,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
         ],
+        indirect=["returns"],
     )
     def test_cum_returns(self, returns, starting_value, expected):
         cum_returns = self.empyrical.cum_returns(
@@ -269,12 +120,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, starting_value, expected",
         [
-            (empty_returns, 0, np.nan),
-            (one_return, 0, one_return[0]),
-            (mixed_returns, 0, 0.03893),
-            (mixed_returns, 100, 103.89310),
-            (negative_returns, 0, -0.36590),
+            ("empty_returns", 0, np.nan),
+            ("one_return", 0, 0.01),
+            ("mixed_returns", 0, 0.03893),
+            ("mixed_returns", 100, 103.89310),
+            ("negative_returns", 0, -0.36590),
         ],
+        indirect=["returns"],
     )
     def test_cum_returns_final(self, returns, starting_value, expected):
         cum_returns_final = self.empyrical.cum_returns_final(
@@ -287,22 +139,26 @@ class TestStats(BaseTestClass):
         "returns, convert_to, expected",
         [
             (
-                simple_benchmark,
+                "simple_benchmark",
                 empyrical.WEEKLY,
                 [0.0, 0.040604010000000024, 0.0],
             ),
-            (simple_benchmark, empyrical.MONTHLY, [0.01, 0.03030099999999991]),
-            (simple_benchmark, empyrical.QUARTERLY, [0.04060401]),
-            (simple_benchmark, empyrical.YEARLY, [0.040604010000000024]),
             (
-                weekly_returns,
+                "simple_benchmark",
+                empyrical.MONTHLY,
+                [0.01, 0.03030099999999991],
+            ),
+            ("simple_benchmark", empyrical.QUARTERLY, [0.04060401]),
+            ("simple_benchmark", empyrical.YEARLY, [0.040604010000000024]),
+            (
+                "weekly_returns",
                 empyrical.MONTHLY,
                 [0.0, 0.087891200000000058, -0.04500459999999995],
             ),
-            (weekly_returns, empyrical.YEARLY, [0.038931091700480147]),
-            (monthly_returns, empyrical.YEARLY, [0.038931091700480147]),
+            ("weekly_returns", empyrical.YEARLY, [0.038931091700480147]),
+            ("monthly_returns", empyrical.YEARLY, [0.038931091700480147]),
             (
-                monthly_returns,
+                "monthly_returns",
                 empyrical.QUARTERLY,
                 [
                     0.11100000000000021,
@@ -311,6 +167,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
         ],
+        indirect=["returns"],
     )
     def test_aggregate_returns(self, returns, convert_to, expected):
         returns = aggregate_returns(returns, convert_to).values.tolist()
@@ -320,25 +177,23 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, expected",
         [
-            (empty_returns, np.nan),
-            (one_return, 0.0),
-            (simple_benchmark, 0.0),
-            (mixed_returns, -0.1),
-            (positive_returns, -0.0),
+            ("empty_returns", np.nan),
+            ("one_return", 0.0),
+            ("simple_benchmark", 0.0),
+            ("mixed_returns", -0.1),
+            ("positive_returns", -0.0),
             # negative returns means the drawdown is just the returns
-            (negative_returns, empyrical.cum_returns_final(negative_returns)),
+            ("negative_returns", -0.36590730),
             (
-                all_negative_returns,
-                empyrical.cum_returns_final(all_negative_returns),
+                "all_negative_returns",
+                -0.378589157,
             ),
             (
-                pd.Series(
-                    np.array([10, -10, 10]) / 100,
-                    index=pd.date_range("2000-1-30", periods=3, freq="D"),
-                ),
+                "udu_returns",
                 -0.10,
             ),
         ],
+        indirect=["returns"],
     )
     def test_max_drawdown(self, returns, expected):
         np.testing.assert_almost_equal(
@@ -354,11 +209,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, constant",
         [
-            (noise, 0.0001),
-            (noise, 0.001),
-            (noise_uniform, 0.01),
-            (noise_uniform, 0.1),
+            ("noise", 0.0001),
+            ("noise", 0.001),
+            ("noise_uniform", 0.01),
+            ("noise_uniform", 0.1),
         ],
+        indirect=["returns"],
     )
     def test_max_drawdown_translation(self, returns, constant):
         depressed_returns = returns - constant
@@ -372,10 +228,11 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, period, expected",
         [
-            (mixed_returns, empyrical.DAILY, 1.9135925373194231),
-            (weekly_returns, empyrical.WEEKLY, 0.24690830513998208),
-            (monthly_returns, empyrical.MONTHLY, 0.052242061386048144),
+            ("mixed_returns", empyrical.DAILY, 1.9135925373194231),
+            ("weekly_returns", empyrical.WEEKLY, 0.24690830513998208),
+            ("monthly_returns", empyrical.MONTHLY, 0.052242061386048144),
         ],
+        indirect=["returns"],
     )
     def test_annual_ret(self, returns, period, expected):
         np.testing.assert_almost_equal(
@@ -387,11 +244,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, period, expected",
         [
-            (flat_line_1_tz, empyrical.DAILY, 0.0),
-            (mixed_returns, empyrical.DAILY, 0.9136465399704637),
-            (weekly_returns, empyrical.WEEKLY, 0.38851569394870583),
-            (monthly_returns, empyrical.MONTHLY, 0.18663690238892558),
+            ("flat_line_1_tz", empyrical.DAILY, 0.0),
+            ("mixed_returns", empyrical.DAILY, 0.9136465399704637),
+            ("weekly_returns", empyrical.WEEKLY, 0.38851569394870583),
+            ("monthly_returns", empyrical.MONTHLY, 0.18663690238892558),
         ],
+        indirect=["returns"],
     )
     def test_annual_volatility(self, returns, period, expected):
         np.testing.assert_almost_equal(
@@ -403,12 +261,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, period, expected",
         [
-            (empty_returns, empyrical.DAILY, np.nan),
-            (one_return, empyrical.DAILY, np.nan),
-            (mixed_returns, empyrical.DAILY, 19.135925373194233),
-            (weekly_returns, empyrical.WEEKLY, 2.4690830513998208),
-            (monthly_returns, empyrical.MONTHLY, 0.52242061386048144),
+            ("empty_returns", empyrical.DAILY, np.nan),
+            ("one_return", empyrical.DAILY, np.nan),
+            ("mixed_returns", empyrical.DAILY, 19.135925373194233),
+            ("weekly_returns", empyrical.WEEKLY, 2.4690830513998208),
+            ("monthly_returns", empyrical.MONTHLY, 0.52242061386048144),
         ],
+        indirect=["returns"],
     )
     def test_calmar(self, returns, period, expected):
         np.testing.assert_almost_equal(
@@ -421,16 +280,17 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, risk_free, required_return, expected",
         [
-            (empty_returns, 0.0, 0.0, np.nan),
-            (one_return, 0.0, 0.0, np.nan),
-            (mixed_returns, 0.0, 10.0, 0.83354263497557934),
-            (mixed_returns, 0.0, -10.0, np.nan),
-            (mixed_returns, flat_line_1, 0.0, 0.8125),
-            (positive_returns, 0.01, 0.0, np.nan),
-            (positive_returns, 0.011, 0.0, 1.125),
-            (positive_returns, 0.02, 0.0, 0.0),
-            (negative_returns, 0.01, 0.0, 0.0),
+            ("empty_returns", "0.0", 0.0, np.nan),
+            ("one_return", "0.0", 0.0, np.nan),
+            ("mixed_returns", "0.0", 10.0, 0.83354263497557934),
+            ("mixed_returns", "0.0", -10.0, np.nan),
+            ("mixed_returns", "flat_line_1", 0.0, 0.8125),
+            ("positive_returns", "0.01", 0.0, np.nan),
+            ("positive_returns", "0.011", 0.0, 1.125),
+            ("positive_returns", "0.02", 0.0, 0.0),
+            ("negative_returns", "0.01", 0.0, 0.0),
         ],
+        indirect=["returns", "risk_free"],
     )
     def test_omega(self, returns, risk_free, required_return, expected):
         np.testing.assert_almost_equal(
@@ -446,9 +306,10 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, required_return_less, required_return_more",
         [
-            (noise_uniform, 0.0, 0.001),
-            (noise, 0.001, 0.002),
+            ("noise_uniform", 0.0, 0.001),
+            ("noise", 0.001, 0.002),
         ],
+        indirect=["returns"],
     )
     def test_omega_returns(
         self, returns, required_return_less, required_return_more
@@ -461,15 +322,16 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, risk_free, expected",
         [
-            (empty_returns, 0.0, np.nan),
-            (one_return, 0.0, np.nan),
-            (mixed_returns, mixed_returns, np.nan),
-            (mixed_returns, 0.0, 1.7238613961706866),
-            (mixed_returns, simple_benchmark, 0.34111411441060574),
-            (positive_returns, 0.0, 52.915026221291804),
-            (negative_returns, 0.0, -24.406808633910085),
-            (flat_line_1, 0.0, np.inf),
+            ("empty_returns", "0.0", np.nan),
+            ("one_return", "0.0", np.nan),
+            ("mixed_returns", "mixed_returns", np.nan),
+            ("mixed_returns", "0.0", 1.7238613961706866),
+            ("mixed_returns", "simple_benchmark", 0.34111411441060574),
+            ("positive_returns", "0.0", 52.915026221291804),
+            ("negative_returns", "0.0", -24.406808633910085),
+            ("flat_line_1", "0.0", np.inf),
         ],
+        indirect=["returns", "risk_free"],
     )
     def test_sharpe_ratio(self, returns, risk_free, expected):
         np.testing.assert_almost_equal(
@@ -482,7 +344,11 @@ class TestStats(BaseTestClass):
     # does not change the sharpe ratio.
     @pytest.mark.parametrize(
         "returns, required_return, translation",
-        [(noise_uniform, 0, 0.005), (noise_uniform, 0.005, 0.005)],
+        [
+            ("noise_uniform", 0, 0.005),
+            ("noise_uniform", 0.005, 0.005),
+        ],
+        indirect=["returns"],
     )
     def test_sharpe_translation_same(
         self, returns, required_return, translation
@@ -502,9 +368,10 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, required_return, translation_returns, translation_required",
         [
-            (noise_uniform, 0, 0.0002, 0.0001),
-            (noise_uniform, 0.005, 0.0001, 0.0002),
+            ("noise_uniform", 0, 0.0002, 0.0001),
+            ("noise_uniform", 0.005, 0.0001, 0.0002),
         ],
+        indirect=["returns"],
     )
     def test_sharpe_translation_diff(
         self,
@@ -528,7 +395,8 @@ class TestStats(BaseTestClass):
     # Translating the required return inversely affects the sharpe ratio.
     @pytest.mark.parametrize(
         "returns, required_return, translation",
-        [(noise_uniform, 0, 0.005), (noise, 0, 0.005)],
+        [("noise_uniform", 0, 0.005), ("noise", 0, 0.005)],
+        indirect=["returns"],
     )
     def test_sharpe_translation_1(self, returns, required_return, translation):
         sr = self.empyrical.sharpe_ratio(returns, required_return)
@@ -562,18 +430,18 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, required_return, period, expected",
         [
-            (empty_returns, 0.0, empyrical.DAILY, np.nan),
-            (one_return, 0.0, empyrical.DAILY, 0.0),
-            (mixed_returns, mixed_returns, empyrical.DAILY, 0.0),
-            (mixed_returns, 0.0, empyrical.DAILY, 0.60448325038829653),
-            (mixed_returns, 0.1, empyrical.DAILY, 1.7161730681956295),
-            (weekly_returns, 0.0, empyrical.WEEKLY, 0.25888650451930134),
-            (weekly_returns, 0.1, empyrical.WEEKLY, 0.7733045971672482),
-            (monthly_returns, 0.0, empyrical.MONTHLY, 0.1243650540411842),
-            (monthly_returns, 0.1, empyrical.MONTHLY, 0.37148351242013422),
+            ("empty_returns", "0.0", empyrical.DAILY, np.nan),
+            ("one_return", "0.0", empyrical.DAILY, 0.0),
+            ("mixed_returns", "mixed_returns", empyrical.DAILY, 0.0),
+            ("mixed_returns", "0.0", empyrical.DAILY, 0.60448325038829653),
+            ("mixed_returns", "0.1", empyrical.DAILY, 1.7161730681956295),
+            ("weekly_returns", "0.0", empyrical.WEEKLY, 0.25888650451930134),
+            ("weekly_returns", "0.1", empyrical.WEEKLY, 0.7733045971672482),
+            ("monthly_returns", "0.0", empyrical.MONTHLY, 0.1243650540411842),
+            ("monthly_returns", "0.1", empyrical.MONTHLY, 0.37148351242013422),
             (
-                df_simple,
-                0.0,
+                "df_simple",
+                "0.0",
                 empyrical.DAILY,
                 pd.Series(
                     [0.20671788246185202, 0.083495680595704475],
@@ -581,8 +449,8 @@ class TestStats(BaseTestClass):
                 ),
             ),
             (
-                df_week,
-                0.0,
+                "df_week",
+                "0.0",
                 empyrical.WEEKLY,
                 pd.Series(
                     [0.093902996054410062, 0.037928477556776516],
@@ -590,8 +458,8 @@ class TestStats(BaseTestClass):
                 ),
             ),
             (
-                df_month,
-                0.0,
+                "df_month",
+                "0.0",
                 empyrical.MONTHLY,
                 pd.Series(
                     [0.045109540184877193, 0.018220251263412916],
@@ -599,6 +467,7 @@ class TestStats(BaseTestClass):
                 ),
             ),
         ],
+        indirect=["returns", "required_return"],
     )
     def test_downside_risk(self, returns, required_return, period, expected):
         downside_risk = self.empyrical.downside_risk(
@@ -617,22 +486,25 @@ class TestStats(BaseTestClass):
     # As a higher percentage of returns are below the required return,
     # downside risk increases.
     @pytest.mark.parametrize(
-        "noise, flat_line",
-        [(noise, flat_line_0), (noise_uniform, flat_line_0)],
+        "add_noise, returns",
+        [("noise", "flat_line_0"), ("noise_uniform", "flat_line_0")],
+        indirect=True,
     )
-    def test_downside_risk_noisy(self, noise, flat_line):
-        noisy_returns_1 = noise[0:250].add(flat_line[250:], fill_value=0)
-        noisy_returns_2 = noise[0:500].add(flat_line[500:], fill_value=0)
-        noisy_returns_3 = noise[0:750].add(flat_line[750:], fill_value=0)
-        dr_1 = self.empyrical.downside_risk(noisy_returns_1, flat_line)
-        dr_2 = self.empyrical.downside_risk(noisy_returns_2, flat_line)
-        dr_3 = self.empyrical.downside_risk(noisy_returns_3, flat_line)
+    def test_downside_risk_noisy(self, add_noise, returns):
+        noisy_returns_1 = add_noise[0:250].add(returns[250:], fill_value=0)
+        noisy_returns_2 = add_noise[0:500].add(returns[500:], fill_value=0)
+        noisy_returns_3 = add_noise[0:750].add(returns[750:], fill_value=0)
+        dr_1 = self.empyrical.downside_risk(noisy_returns_1, returns)
+        dr_2 = self.empyrical.downside_risk(noisy_returns_2, returns)
+        dr_3 = self.empyrical.downside_risk(noisy_returns_3, returns)
         assert dr_1 <= dr_2
         assert dr_2 <= dr_3
 
     # Downside risk increases as the required_return increases
     @pytest.mark.parametrize(
-        "returns, required_return", [(noise, 0.005), (noise_uniform, 0.005)]
+        "returns, required_return",
+        [("noise", 0.005), ("noise_uniform", 0.005)],
+        indirect=["returns"],
     )
     def test_downside_risk_trans(self, returns, required_return):
         dr_0 = self.empyrical.downside_risk(returns, -required_return)
@@ -671,19 +543,24 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, required_return, period, expected",
         [
-            (empty_returns, 0.0, empyrical.DAILY, np.nan),
-            (one_return, 0.0, empyrical.DAILY, np.nan),
-            (mixed_returns, mixed_returns, empyrical.DAILY, np.nan),
-            (mixed_returns, 0.0, empyrical.DAILY, 2.605531251673693),
-            (mixed_returns, flat_line_1, empyrical.DAILY, -1.3934779588919977),
-            (positive_returns, 0.0, empyrical.DAILY, np.inf),
-            (negative_returns, 0.0, empyrical.DAILY, -13.532743075043401),
-            (simple_benchmark, 0.0, empyrical.DAILY, np.inf),
-            (weekly_returns, 0.0, empyrical.WEEKLY, 1.1158901056866439),
-            (monthly_returns, 0.0, empyrical.MONTHLY, 0.53605626741889756),
+            ("empty_returns", "0.0", empyrical.DAILY, np.nan),
+            ("one_return", "0.0", empyrical.DAILY, np.nan),
+            ("mixed_returns", "mixed_returns", empyrical.DAILY, np.nan),
+            ("mixed_returns", "0.0", empyrical.DAILY, 2.605531251673693),
             (
-                df_simple,
-                0.0,
+                "mixed_returns",
+                "flat_line_1",
+                empyrical.DAILY,
+                -1.3934779588919977,
+            ),
+            ("positive_returns", "0.0", empyrical.DAILY, np.inf),
+            ("negative_returns", "0.0", empyrical.DAILY, -13.532743075043401),
+            ("simple_benchmark", "0.0", empyrical.DAILY, np.inf),
+            ("weekly_returns", "0.0", empyrical.WEEKLY, 1.1158901056866439),
+            ("monthly_returns", "0.0", empyrical.MONTHLY, 0.53605626741889756),
+            (
+                "df_simple",
+                "0.0",
                 empyrical.DAILY,
                 pd.Series(
                     [3.0639640966566306, 38.090963117002495],
@@ -691,8 +568,8 @@ class TestStats(BaseTestClass):
                 ),
             ),
             (
-                df_week,
-                0.0,
+                "df_week",
+                "0.0",
                 empyrical.WEEKLY,
                 pd.Series(
                     [1.3918264112070571, 17.303077589064618],
@@ -700,8 +577,8 @@ class TestStats(BaseTestClass):
                 ),
             ),
             (
-                df_month,
-                0.0,
+                "df_month",
+                "0.0",
                 empyrical.MONTHLY,
                 pd.Series(
                     [0.6686117809312383, 8.3121296084492844],
@@ -709,6 +586,7 @@ class TestStats(BaseTestClass):
                 ),
             ),
         ],
+        indirect=["returns", "required_return"],
     )
     def test_sortino(self, returns, required_return, period, expected):
         sortino_ratio = self.empyrical.sortino_ratio(
@@ -730,9 +608,10 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, required_return",
         [
-            (noise_uniform, 0),
-            (noise, 0),
+            ("noise_uniform", "0"),
+            ("noise", "0"),
         ],
+        indirect=True,
     )
     def test_sortino_add_noise(self, returns, required_return):
         # Don't mutate global test state
@@ -751,7 +630,9 @@ class TestStats(BaseTestClass):
     # Similarly, randomly increasing some values below the required return to
     # the required return increases the ratio.
     @pytest.mark.parametrize(
-        "returns, required_return", [(noise_uniform, 0), (noise, 0)]
+        "returns, required_return",
+        [("noise_uniform", "0"), ("noise", "0")],
+        indirect=True,
     )
     def test_sortino_sub_noise(self, returns, required_return):
         # Don't mutate global test state
@@ -771,7 +652,8 @@ class TestStats(BaseTestClass):
     # should not change the sortino ratio.
     @pytest.mark.parametrize(
         "returns, required_return, translation",
-        [(noise_uniform, 0, 0.005), (noise_uniform, 0.005, 0.005)],
+        [("noise_uniform", 0, 0.005), ("noise_uniform", 0.005, 0.005)],
+        indirect=["returns"],
     )
     def test_sortino_translation_same(
         self, returns, required_return, translation
@@ -790,7 +672,8 @@ class TestStats(BaseTestClass):
     # should not change the sortino ratio.
     @pytest.mark.parametrize(
         "returns, required_return, translation_returns, translation_required",
-        [(noise_uniform, 0, 0, 0.001), (noise_uniform, 0.005, 0.001, 0)],
+        [("noise_uniform", 0, 0, 0.001), ("noise_uniform", 0.005, 0.001, 0)],
+        indirect=["returns"],
     )
     def test_sortino_translation_diff(
         self,
@@ -815,12 +698,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, expected",
         [
-            (empty_returns, 0.0, np.nan),
-            (one_return, 0.0, np.nan),
-            (pos_line, pos_line, np.nan),
-            (mixed_returns, 0.0, 0.10859306069076737),
-            (mixed_returns, flat_line_1, -0.06515583641446039),
+            ("empty_returns", "0.0", np.nan),
+            ("one_return", "0.0", np.nan),
+            ("pos_line", "pos_line", np.nan),
+            ("mixed_returns", "0.0", 0.10859306069076737),
+            ("mixed_returns", "flat_line_1", -0.06515583641446039),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_excess_sharpe(self, returns, factor_returns, expected):
         np.testing.assert_almost_equal(
@@ -832,17 +716,18 @@ class TestStats(BaseTestClass):
     # The magnitude of the information ratio increases as a higher
     # proportion of returns are uncorrelated with the benchmark.
     @pytest.mark.parametrize(
-        "noise_line, benchmark",
+        "returns, benchmark",
         [
-            (flat_line_0, pos_line),
-            (flat_line_1_tz, pos_line),
-            (noise, pos_line),
+            ("flat_line_0", "pos_line"),
+            ("flat_line_1_tz", "pos_line"),
+            ("noise", "pos_line"),
         ],
+        indirect=True,
     )
-    def test_excess_sharpe_noisy(self, noise_line, benchmark):
-        noisy_returns_1 = noise_line[0:250].add(benchmark[250:], fill_value=0)
-        noisy_returns_2 = noise_line[0:500].add(benchmark[500:], fill_value=0)
-        noisy_returns_3 = noise_line[0:750].add(benchmark[750:], fill_value=0)
+    def test_excess_sharpe_noisy(self, returns, benchmark):
+        noisy_returns_1 = returns[0:250].add(benchmark[250:], fill_value=0)
+        noisy_returns_2 = returns[0:500].add(benchmark[500:], fill_value=0)
+        noisy_returns_3 = returns[0:750].add(benchmark[750:], fill_value=0)
         ir_1 = self.empyrical.excess_sharpe(noisy_returns_1, benchmark)
         ir_2 = self.empyrical.excess_sharpe(noisy_returns_2, benchmark)
         ir_3 = self.empyrical.excess_sharpe(noisy_returns_3, benchmark)
@@ -852,21 +737,22 @@ class TestStats(BaseTestClass):
     # Vertical translations change the information ratio in the
     # direction of the translation.
     @pytest.mark.parametrize(
-        "returns, add_noise, translation",
+        "returns, add_noise, benchmark",
         [
-            (pos_line, noise, flat_line_1_tz),
-            (pos_line, inv_noise, flat_line_1_tz),
-            (neg_line, noise, flat_line_1_tz),
-            (neg_line, inv_noise, flat_line_1_tz),
+            ("pos_line", "noise", "flat_line_1_tz"),
+            ("pos_line", "inv_noise", "flat_line_1_tz"),
+            ("neg_line", "noise", "flat_line_1_tz"),
+            ("neg_line", "inv_noise", "flat_line_1_tz"),
         ],
+        indirect=True,
     )
-    def test_excess_sharpe_trans(self, returns, add_noise, translation):
+    def test_excess_sharpe_trans(self, returns, add_noise, benchmark):
         ir = self.empyrical.excess_sharpe(returns + add_noise, returns)
         raised_ir = self.empyrical.excess_sharpe(
-            returns + add_noise + translation, returns
+            returns + add_noise + benchmark, returns
         )
         depressed_ir = self.empyrical.excess_sharpe(
-            returns + add_noise - translation, returns
+            returns + add_noise - benchmark, returns
         )
         assert ir < raised_ir
         assert depressed_ir < ir
@@ -874,16 +760,17 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark, expected",
         [
-            (empty_returns, simple_benchmark, (np.nan, np.nan)),
-            (one_return, one_return, (np.nan, np.nan)),
+            ("empty_returns", "simple_benchmark", (np.nan, np.nan)),
+            ("one_return", "one_return", (np.nan, np.nan)),
             (
-                mixed_returns,
-                negative_returns[1:],
+                "mixed_returns",
+                "negative_returns[1:]",
                 (-0.9997853834885004, -0.71296296296296313),
             ),
-            (mixed_returns, mixed_returns, (0.0, 1.0)),
-            (mixed_returns, -mixed_returns, (0.0, -1.0)),
+            ("mixed_returns", "mixed_returns", (0.0, 1.0)),
+            ("mixed_returns", "-mixed_returns", (0.0, -1.0)),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_alpha_beta(self, returns, benchmark, expected):
         alpha, beta = alpha_beta(returns, benchmark)
@@ -895,12 +782,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark, expected",
         [
-            (empty_returns, simple_benchmark, np.nan),
-            (one_return, one_return, np.nan),
-            (mixed_returns, flat_line_1, np.nan),
-            (mixed_returns, mixed_returns, 0.0),
-            (mixed_returns, -mixed_returns, 0.0),
+            ("empty_returns", "simple_benchmark", np.nan),
+            ("one_return", "one_return", np.nan),
+            ("mixed_returns", "flat_line_1", np.nan),
+            ("mixed_returns", "mixed_returns", 0.0),
+            ("mixed_returns", "-mixed_returns", 0.0),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_alpha(self, returns, benchmark, expected):
         observed = self.empyrical.alpha(returns, benchmark)
@@ -1022,8 +910,9 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark",
         [
-            (sparse_noise, sparse_noise),
+            ("sparse_noise", "sparse_noise"),
         ],
+        indirect=True,
     )
     def test_alpha_beta_with_nan_inputs(self, returns, benchmark):
         alpha, beta = self.empyrical(return_types=np.ndarray).alpha_beta(
@@ -1036,27 +925,27 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark, expected, decimal_places",
         [
-            (empty_returns, simple_benchmark, np.nan, DECIMAL_PLACES),
-            (one_return, one_return, np.nan, DECIMAL_PLACES),
-            (mixed_returns, flat_line_1, np.nan, DECIMAL_PLACES),
-            (noise, noise, 1.0, DECIMAL_PLACES),
-            (2 * noise, noise, 2.0, DECIMAL_PLACES),
-            (noise, inv_noise, -1.0, DECIMAL_PLACES),
-            (2 * noise, inv_noise, -2.0, DECIMAL_PLACES),
+            ("empty_returns", "simple_benchmark", np.nan, DECIMAL_PLACES),
+            ("one_return", "one_return", np.nan, DECIMAL_PLACES),
+            ("mixed_returns", "flat_line_1", np.nan, DECIMAL_PLACES),
+            ("noise", "noise", 1.0, DECIMAL_PLACES),
+            ("2 * noise", "noise", 2.0, DECIMAL_PLACES),
+            ("noise", "inv_noise", -1.0, DECIMAL_PLACES),
+            ("2 * noise", "inv_noise", -2.0, DECIMAL_PLACES),
             (
-                sparse_noise * flat_line_1_tz,
-                sparse_flat_line_1_tz,
+                "sparse_noise * flat_line_1_tz",
+                "sparse_flat_line_1_tz",
                 np.nan,
                 DECIMAL_PLACES,
             ),
             (
-                simple_benchmark
-                + rand.normal(0, 0.001, len(simple_benchmark)),
-                pd.DataFrame({"returns": simple_benchmark}),
+                "simple_benchmark_w_noise",
+                "simple_benchmark_df",
                 1.0,
                 2,
             ),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_beta(
         self,
@@ -1090,14 +979,15 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark",
         [
-            (empty_returns, simple_benchmark),
-            (one_return, one_return),
+            ("empty_returns", "simple_benchmark"),
+            ("one_return", "one_return"),
             # TODO: these are failing, disabling for now
             # (mixed_returns, simple_benchmark[1:]),
             # (mixed_returns, negative_returns[1:]),
-            (mixed_returns, mixed_returns),
-            (mixed_returns, -mixed_returns),
+            ("mixed_returns", "mixed_returns"),
+            ("mixed_returns", "-mixed_returns"),
         ],
+        indirect=True,
     )
     def test_alpha_beta_equality(self, returns, benchmark):
         alpha, beta = alpha_beta(returns, benchmark)
@@ -1123,11 +1013,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, expected",
         [
-            (empty_returns, np.nan),
-            (one_return, np.nan),
-            (mixed_returns, 0.1529973665111273),
-            (flat_line_1_tz, 1.0),
+            ("empty_returns", np.nan),
+            ("one_return", np.nan),
+            ("mixed_returns", 0.1529973665111273),
+            ("flat_line_1_tz", 1.0),
         ],
+        indirect=["returns"],
     )
     def test_stability_of_timeseries(self, returns, expected):
         np.testing.assert_almost_equal(
@@ -1139,11 +1030,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, expected",
         [
-            (empty_returns, np.nan),
-            (one_return, 1.0),
-            (mixed_returns, 0.9473684210526313),
-            (pd.Series(rand.randn(100000)), 1.0),
+            ("empty_returns", np.nan),
+            ("one_return", 1.0),
+            ("mixed_returns", 0.9473684210526313),
+            ("random_100k", 1.0),
         ],
+        indirect=["returns"],
     )
     def test_tail_ratio(self, returns, expected):
         np.testing.assert_almost_equal(
@@ -1154,19 +1046,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, period, expected",
         [
-            (empty_returns, empyrical.DAILY, np.nan),
-            (one_return, empyrical.DAILY, 11.274002099240244),
-            (mixed_returns, empyrical.DAILY, 1.9135925373194231),
-            (flat_line_1_tz, empyrical.DAILY, 11.274002099240256),
-            (
-                pd.Series(
-                    np.array([3.0, 3.0, 3.0]) / 100,
-                    index=pd.date_range("2000-1-30", periods=3, freq="A"),
-                ),
-                "yearly",
-                0.03,
-            ),
+            ("empty_returns", empyrical.DAILY, np.nan),
+            ("one_return", empyrical.DAILY, 11.274002099240244),
+            ("mixed_returns", empyrical.DAILY, 1.9135925373194231),
+            ("flat_line_1_tz", empyrical.DAILY, 11.274002099240256),
+            ("flat_line_yearly", empyrical.YEARLY, 0.03),
         ],
+        indirect=["returns"],
     )
     def test_cagr(self, returns, period, expected):
         np.testing.assert_almost_equal(
@@ -1179,7 +1065,9 @@ class TestStats(BaseTestClass):
     # translating returns by a constant will change cagr in the same
     # direction of translation.
     @pytest.mark.parametrize(
-        "returns, constant", [(noise, 0.01), (noise_uniform, 0.01)]
+        "returns, constant",
+        [("noise", 0.01), ("noise_uniform", 0.01)],
+        indirect=["returns"],
     )
     def test_cagr_translation(self, returns, constant):
         cagr_depressed = self.empyrical.cagr(returns - constant)
@@ -1189,7 +1077,7 @@ class TestStats(BaseTestClass):
         assert cagr_unchanged < cagr_raised
 
     # Function does not return np.nan when inputs contain np.nan.
-    @pytest.mark.parametrize("returns", [sparse_noise])
+    @pytest.mark.parametrize("returns", ["sparse_noise"], indirect=True)
     def test_cagr_with_nan_inputs(self, returns):
         assert not np.isnan(self.empyrical.cagr(returns))
 
@@ -1199,10 +1087,11 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, add_noise",
         [
-            (pos_line, noise),
-            (pos_line, noise_uniform),
-            (flat_line_1_tz, noise),
+            ("pos_line", "noise"),
+            ("pos_line", "noise_uniform"),
+            ("flat_line_1_tz", "noise"),
         ],
+        indirect=True,
     )
     def test_cagr_noisy(self, returns, add_noise):
         cagr = self.empyrical.cagr(returns)
@@ -1215,11 +1104,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, expected",
         [
-            (one_return, one_return, np.nan),
-            (positive_returns, simple_benchmark, 0.0),
-            (mixed_returns, simple_benchmark, 0.09),
-            (negative_returns, simple_benchmark, -0.029999999999999999),
+            ("one_return", "one_return", np.nan),
+            ("positive_returns", "simple_benchmark", 0.0),
+            ("mixed_returns", "simple_benchmark", 0.09),
+            ("negative_returns", "simple_benchmark", -0.029999999999999999),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_beta_fragility_heuristic(self, returns, factor_returns, expected):
         np.testing.assert_almost_equal(
@@ -1228,36 +1118,21 @@ class TestStats(BaseTestClass):
             DECIMAL_PLACES,
         )
 
-    mixed_returns_expected_gpd_risk_result = [
-        0.1,
-        0.10001255835838491,
-        1.5657360018514067e-06,
-        0.4912526273742347,
-        0.59126595492541179,
-    ]
-
-    negative_returns_expected_gpd_risk_result = [
-        0.05,
-        0.068353586736348199,
-        9.4304947982121171e-07,
-        0.34511639904932639,
-        0.41347032855617882,
-    ]
-
     # regression tests for gpd_risk_estimates
     @pytest.mark.parametrize(
         "returns, expected",
         [
-            (one_return, [0, 0, 0, 0, 0]),
-            (empty_returns, [0, 0, 0, 0, 0]),
-            (simple_benchmark, [0, 0, 0, 0, 0]),
-            (positive_returns, [0, 0, 0, 0, 0]),
-            (negative_returns, negative_returns_expected_gpd_risk_result),
-            (mixed_returns, mixed_returns_expected_gpd_risk_result),
-            (flat_line_1, [0, 0, 0, 0]),
-            (weekly_returns, mixed_returns_expected_gpd_risk_result),
-            (monthly_returns, mixed_returns_expected_gpd_risk_result),
+            ("one_return", "[0, 0, 0, 0, 0]"),
+            ("empty_returns", "[0, 0, 0, 0, 0]"),
+            ("simple_benchmark", "[0, 0, 0, 0, 0]"),
+            ("positive_returns", "[0, 0, 0, 0, 0]"),
+            ("negative_returns", "negative_returns_expected_gpd_risk_result"),
+            ("mixed_returns", "mixed_returns_expected_gpd_risk_result"),
+            ("flat_line_1", "[0, 0, 0, 0]"),
+            ("weekly_returns", "mixed_returns_expected_gpd_risk_result"),
+            ("monthly_returns", "mixed_returns_expected_gpd_risk_result"),
         ],
+        indirect=["returns", "expected"],
     )
     def test_gpd_risk_estimates(self, returns, expected):
         result = self.empyrical.gpd_risk_estimates_aligned(returns)
@@ -1269,9 +1144,10 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, window, expected",
         [
-            (empty_returns, 6, []),
-            (negative_returns, 6, [-0.2282, -0.2745, -0.2899, -0.2747]),
+            ("empty_returns", 6, []),
+            ("negative_returns", 6, [-0.2282, -0.2745, -0.2899, -0.2747]),
         ],
+        indirect=["returns"],
     )
     def test_roll_max_drawdown(self, returns, window, expected):
         test = self.empyrical.roll_max_drawdown(returns, window=window)
@@ -1284,18 +1160,19 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, window, expected",
         [
-            (empty_returns, 6, []),
+            ("empty_returns", 6, []),
             (
-                negative_returns,
+                "negative_returns",
                 6,
                 [-18.09162052, -26.79897486, -26.69138263, -25.72298838],
             ),
             (
-                mixed_returns,
+                "mixed_returns",
                 6,
                 [7.57445259, 8.22784105, 8.22784105, -3.1374751],
             ),
         ],
+        indirect=["returns"],
     )
     def test_roll_sharpe_ratio(self, returns, window, expected):
         test = self.empyrical.roll_sharpe_ratio(returns, window=window)
@@ -1308,11 +1185,12 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, expected",
         [
-            (empty_returns, empty_returns, np.nan),
-            (one_return, one_return, 1.0),
-            (mixed_returns, mixed_returns, 1.0),
-            (all_negative_returns, mixed_returns, -0.52257643222960259),
+            ("empty_returns", "empty_returns", np.nan),
+            ("one_return", "one_return", 1.0),
+            ("mixed_returns", "mixed_returns", 1.0),
+            ("all_negative_returns", "mixed_returns", -0.52257643222960259),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_capture_ratio(self, returns, factor_returns, expected):
         np.testing.assert_almost_equal(
@@ -1324,12 +1202,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, expected",
         [
-            (empty_returns, empty_returns, np.nan),
-            (one_return, one_return, np.nan),
-            (mixed_returns, mixed_returns, 1.0),
-            (all_negative_returns, mixed_returns, 0.99956025703798634),
-            (positive_returns, mixed_returns, -11.27400221),
+            ("empty_returns", "empty_returns", np.nan),
+            ("one_return", "one_return", np.nan),
+            ("mixed_returns", "mixed_returns", 1.0),
+            ("all_negative_returns", "mixed_returns", 0.99956025703798634),
+            ("positive_returns", "mixed_returns", -11.27400221),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_down_capture(self, returns, factor_returns, expected):
         np.testing.assert_almost_equal(
@@ -1342,15 +1221,15 @@ class TestStats(BaseTestClass):
         "returns, benchmark, window, expected",
         [
             (
-                empty_returns,
-                simple_benchmark,
+                "empty_returns",
+                "simple_benchmark",
                 1,
-                [(np.nan, np.nan)] * len(simple_benchmark),
+                [(np.nan, np.nan)] * 9,
             ),
-            (one_return, one_return, 1, [(np.nan, np.nan)]),
+            ("one_return", "one_return", 1, [(np.nan, np.nan)]),
             (
-                mixed_returns,
-                negative_returns,
+                "mixed_returns",
+                "negative_returns",
                 6,
                 [
                     (-0.97854954, -0.7826087),
@@ -1360,18 +1239,19 @@ class TestStats(BaseTestClass):
                 ],
             ),
             (
-                mixed_returns,
-                mixed_returns,
+                "mixed_returns",
+                "mixed_returns",
                 6,
                 [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0), (0.0, 1.0)],
             ),
             (
-                mixed_returns,
-                -mixed_returns,
+                "mixed_returns",
+                "-mixed_returns",
                 6,
                 [(0.0, -1.0), (0.0, -1.0), (0.0, -1.0), (0.0, -1.0)],
             ),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_roll_alpha_beta(self, returns, benchmark, window, expected):
         test = self.empyrical(
@@ -1406,18 +1286,18 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, window, expected",
         [
-            (empty_returns, empty_returns, 1, []),
-            (one_return, one_return, 1, np.nan),
-            (mixed_returns, mixed_returns, 6, [1.0, 1.0, 1.0, 1.0]),
+            ("empty_returns", "empty_returns", 1, []),
+            ("one_return", "one_return", 1, np.nan),
+            ("mixed_returns", "mixed_returns", 6, [1.0, 1.0, 1.0, 1.0]),
             (
-                positive_returns,
-                mixed_returns,
+                "positive_returns",
+                "mixed_returns",
                 6,
                 [-0.00011389, -0.00025861, -0.00015211, -0.00689239],
             ),
             (
-                all_negative_returns,
-                mixed_returns,
+                "all_negative_returns",
+                "mixed_returns",
                 6,
                 [
                     -6.38880246e-05,
@@ -1427,6 +1307,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_roll_up_down_capture(
         self, returns, factor_returns, window, expected
@@ -1441,22 +1322,23 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, window, expected",
         [
-            (empty_returns, empty_returns, 1, []),
-            (one_return, one_return, 1, [np.nan]),
-            (mixed_returns, mixed_returns, 6, [1.0, 1.0, 1.0, 1.0]),
+            ("empty_returns", "empty_returns", 1, []),
+            ("one_return", "one_return", 1, [np.nan]),
+            ("mixed_returns", "mixed_returns", 6, [1.0, 1.0, 1.0, 1.0]),
             (
-                positive_returns,
-                mixed_returns,
+                "positive_returns",
+                "mixed_returns",
                 6,
                 [-11.2743862, -11.2743862, -11.2743862, -11.27400221],
             ),
             (
-                all_negative_returns,
-                mixed_returns,
+                "all_negative_returns",
+                "mixed_returns",
                 6,
                 [0.92058591, 0.92058591, 0.92058591, 0.99956026],
             ),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_roll_down_capture(
         self, returns, factor_returns, window, expected
@@ -1473,18 +1355,18 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, window, expected",
         [
-            (empty_returns, empty_returns, 1, []),
-            (one_return, one_return, 1, [1.0]),
-            (mixed_returns, mixed_returns, 6, [1.0, 1.0, 1.0, 1.0]),
+            ("empty_returns", "empty_returns", 1, []),
+            ("one_return", "one_return", 1, [1.0]),
+            ("mixed_returns", "mixed_returns", 6, [1.0, 1.0, 1.0, 1.0]),
             (
-                positive_returns,
-                mixed_returns,
+                "positive_returns",
+                "mixed_returns",
                 6,
                 [0.00128406, 0.00291564, 0.00171499, 0.0777048],
             ),
             (
-                all_negative_returns,
-                mixed_returns,
+                "all_negative_returns",
+                "mixed_returns",
                 6,
                 [
                     -5.88144154e-05,
@@ -1494,6 +1376,7 @@ class TestStats(BaseTestClass):
                 ],
             ),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_roll_up_capture(self, returns, factor_returns, window, expected):
         test = self.empyrical.roll_up_capture(
@@ -1508,16 +1391,17 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark, expected",
         [
-            (empty_returns, simple_benchmark, (np.nan, np.nan)),
-            (one_return, one_return, (np.nan, np.nan)),
+            ("empty_returns", "simple_benchmark", (np.nan, np.nan)),
+            ("one_return", "one_return", (np.nan, np.nan)),
             (
-                mixed_returns[1:],
-                negative_returns[1:],
+                "mixed_returns[1:]",
+                "negative_returns[1:]",
                 (-0.9997853834885004, -0.71296296296296313),
             ),
-            (mixed_returns, mixed_returns, (0.0, 1.0)),
-            (mixed_returns, -mixed_returns, (0.0, -1.0)),
+            ("mixed_returns", "mixed_returns", (0.0, 1.0)),
+            ("mixed_returns", "-mixed_returns", (0.0, -1.0)),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_down_alpha_beta(self, returns, benchmark, expected):
         down_alpha, down_beta = down_alpha_beta(returns, benchmark)
@@ -1528,16 +1412,17 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, benchmark, expected",
         [
-            (empty_returns, simple_benchmark, (np.nan, np.nan)),
-            (one_return, one_return, (np.nan, np.nan)),
+            ("empty_returns", "simple_benchmark", (np.nan, np.nan)),
+            ("one_return", "one_return", (np.nan, np.nan)),
             (
-                mixed_returns[1:],
-                positive_returns[1:],
+                "mixed_returns[1:]",
+                "positive_returns[1:]",
                 (0.432961242076658, 0.4285714285),
             ),
-            (mixed_returns, mixed_returns, (0.0, 1.0)),
-            (mixed_returns, -mixed_returns, (0.0, -1.0)),
+            ("mixed_returns", "mixed_returns", (0.0, 1.0)),
+            ("mixed_returns", "-mixed_returns", (0.0, -1.0)),
         ],
+        indirect=["returns", "benchmark"],
     )
     def test_up_alpha_beta(self, returns, benchmark, expected):
         up_alpha, up_beta = up_alpha_beta(returns, benchmark)
@@ -1548,12 +1433,13 @@ class TestStats(BaseTestClass):
     @pytest.mark.parametrize(
         "returns, factor_returns, expected",
         [
-            (empty_returns, empty_returns, np.nan),
-            (one_return, one_return, np.nan),
-            (mixed_returns, mixed_returns, 1.0),
-            (positive_returns, mixed_returns, -0.0006756053495),
-            (all_negative_returns, mixed_returns, -0.0004338236),
+            ("empty_returns", "empty_returns", np.nan),
+            ("one_return", "one_return", np.nan),
+            ("mixed_returns", "mixed_returns", 1.0),
+            ("positive_returns", "mixed_returns", -0.0006756053495),
+            ("all_negative_returns", "mixed_returns", -0.0004338236),
         ],
+        indirect=["returns", "factor_returns"],
     )
     def test_up_down_capture(self, returns, factor_returns, expected):
         np.testing.assert_almost_equal(
@@ -1563,18 +1449,19 @@ class TestStats(BaseTestClass):
         )
 
     @pytest.mark.parametrize(
-        "returns, factor_returns, expected",
+        "returns, benchmark, expected",
         [
-            (empty_returns, empty_returns, np.nan),
-            (one_return, one_return, 1.0),
-            (mixed_returns, mixed_returns, 1.0),
-            (positive_returns, mixed_returns, 0.0076167762),
-            (all_negative_returns, mixed_returns, -0.0004336328),
+            ("empty_returns", "empty_returns", np.nan),
+            ("one_return", "one_return", 1.0),
+            ("mixed_returns", "mixed_returns", 1.0),
+            ("positive_returns", "mixed_returns", 0.0076167762),
+            ("all_negative_returns", "mixed_returns", -0.0004336328),
         ],
+        indirect=["returns", "benchmark"],
     )
-    def test_up_capture(self, returns, factor_returns, expected):
+    def test_up_capture(self, returns, benchmark, expected):
         np.testing.assert_almost_equal(
-            self.empyrical.up_capture(returns, factor_returns),
+            self.empyrical.up_capture(returns, benchmark),
             expected,
             DECIMAL_PLACES,
         )
@@ -1699,23 +1586,7 @@ class TestStatsIntIndex(TestStats):
         pass
 
 
-@pytest.fixture(scope="function")
-def set_helper(request):
-    request.cls.ser_length = 120
-    request.cls.window = 12
-
-    request.cls.returns = pd.Series(
-        rand.randn(1, 120)[0] / 100.0,
-        index=pd.date_range("2000-1-30", periods=120, freq="M"),
-    )
-
-    request.cls.factor_returns = pd.Series(
-        rand.randn(1, 120)[0] / 100.0,
-        index=pd.date_range("2000-1-30", periods=120, freq="M"),
-    )
-
-
-@pytest.mark.usefixtures("set_helper")
+@pytest.mark.usefixtures("set_helpers")
 class TestHelpers(BaseTestClass):
     """
     Tests for helper methods and utils.
@@ -1806,101 +1677,14 @@ class Test2DStats:
         ):
             pd.testing.assert_index_equal(result.columns, expected.columns)
 
-    input_one = [
-        np.nan,
-        0.01322056,
-        0.03063862,
-        -0.01422057,
-        -0.00489779,
-        0.01268925,
-        -0.03357711,
-        0.01797036,
-    ]
-    input_two = [
-        0.01846232,
-        0.00793951,
-        -0.01448395,
-        0.00422537,
-        -0.00339611,
-        0.03756813,
-        0.0151531,
-        np.nan,
-    ]
-
-    expected_0_one = [
-        0.000000,
-        0.013221,
-        0.044264,
-        0.029414,
-        0.024372,
-        0.037371,
-        0.002539,
-        0.020555,
-    ]
-    expected_0_two = [
-        0.018462,
-        0.026548,
-        0.011680,
-        0.015955,
-        0.012504,
-        0.050542,
-        0.066461,
-        0.066461,
-    ]
-
-    expected_100_one = [
-        100.000000,
-        101.322056,
-        104.426424,
-        102.941421,
-        102.437235,
-        103.737087,
-        100.253895,
-        102.055494,
-    ]
-    expected_100_two = [
-        101.846232,
-        102.654841,
-        101.167994,
-        101.595466,
-        101.250436,
-        105.054226,
-        106.646123,
-        106.646123,
-    ]
-
-    df_index = pd.date_range("2000-1-30", periods=8, freq="D")
-
-    df_input = pd.DataFrame(
-        {
-            "one": pd.Series(input_one, index=df_index),
-            "two": pd.Series(input_two, index=df_index),
-        }
-    )
-
-    df_empty = pd.DataFrame()
-
-    df_0_expected = pd.DataFrame(
-        {
-            "one": pd.Series(expected_0_one, index=df_index),
-            "two": pd.Series(expected_0_two, index=df_index),
-        }
-    )
-
-    df_100_expected = pd.DataFrame(
-        {
-            "one": pd.Series(expected_100_one, index=df_index),
-            "two": pd.Series(expected_100_two, index=df_index),
-        }
-    )
-
     @pytest.mark.parametrize(
         "returns, starting_value, expected",
         [
-            (df_input, 0, df_0_expected),
-            (df_input, 100, df_100_expected),
-            (df_empty, 0, pd.DataFrame()),
+            ("df_input", 0, "df_0_expected"),
+            ("df_input", 100, "df_100_expected"),
+            ("df_empty", 0, "df_empty"),
         ],
+        indirect=["returns", "expected"],
     )
     def test_cum_returns_df(self, returns, starting_value, expected):
         cum_returns = self.empyrical.cum_returns(
@@ -1919,9 +1703,10 @@ class Test2DStats:
     @pytest.mark.parametrize(
         "returns, starting_value, expected",
         [
-            (df_input, 0, df_0_expected.iloc[-1]),
-            (df_input, 100, df_100_expected.iloc[-1]),
+            ("df_input", 0, "df_0_expected"),
+            ("df_input", 100, "df_100_expected"),
         ],
+        indirect=["returns", "expected"],
     )
     def test_cum_returns_final_df(self, returns, starting_value, expected):
         return_types = (pd.Series, np.ndarray)
@@ -1929,8 +1714,8 @@ class Test2DStats:
             returns,
             starting_value=starting_value,
         )
-        np.testing.assert_almost_equal(np.array(result), expected, 5)
-        self.assert_indexes_match(result, expected)
+        np.testing.assert_almost_equal(np.array(result), expected.iloc[-1], 5)
+        self.assert_indexes_match(result, expected.iloc[-1])
 
     @property
     def empyrical(self):


### PR DESCRIPTION
- Refactored test by moving the test data into `conftest.py`
- Refactored `stats.py` by moving `_create_unary_vectorized_roll_function`, `_create_binary_vectorized_roll_function`, `_flatten`,  `_adjust_returns`, `_to_pandas` and `_aligned_series` into `utils.py`
- Refactored `max_drawdown`,  introducing  a  function `drawdown_series`  that computes the series of drawdowns of a strategy.
- Included a `batting_average` function
- Added a warnings filter to the the sharpe ration warning raised by the PR from [RichardDale](https://github.com/stefan-jansen/empyrical-reloaded/pull/1). I believe that filtering the warnings  is a better solution than using `numpy.full` 
- Fixed a bug in `load_portfolio_risk_factors` and implemented  start and end_date in `get_fama_french`