### PR TITLE
MAINT: upper bound for scipy 1.7.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     numpy>=1.9.2
     bottleneck>=1.3.0
     pandas>=1.0.0
-    scipy>=0.15.1
+    scipy>=0.15.1,<=1.7.3
     pandas-datareader>=0.4
     yfinance>=0.1.63
 


### PR DESCRIPTION
a few tests fails if scipy is 1.8.x
put an upper bound until the issue is resolved