### PR TITLE
Typo fix in empyrical.stats. roll_downsize_risk -> roll_downside_risk

### DIFF
--- a/src/empyrical/stats.py
+++ b/src/empyrical/stats.py
@@ -832,7 +832,8 @@ def downside_risk(
     return out
 
 
-roll_downsize_risk = _create_unary_vectorized_roll_function(downside_risk)
+roll_downsize_risk = _create_unary_vectorized_roll_function(downside_risk) # Typo spotted. Should be roll_downside_risk. Ideally be depreciated.
+roll_downside_risk = _create_unary_vectorized_roll_function(downside_risk)
 
 
 def excess_sharpe(returns, factor_returns, out=None):


### PR DESCRIPTION
Ideally depreciate `empyrical.stats. roll_downsize_risk` and warn to replace with `empyrical.stats. roll_downside_risk`