### PR TITLE
np.NINF was removed in numpy2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ local_scheme = 'dirty-tag'
 testpaths = 'tests'
 addopts = '-v'
 
+[tool.pytest.ini_options]
+pythonpath = "src/"
+
 [tool.cibuildwheel]
 test-extras = "test"
 test-command = "pytest -n 2 --reruns 5 {package}/tests"

--- a/src/empyrical/stats.py
+++ b/src/empyrical/stats.py
@@ -818,7 +818,7 @@ def downside_risk(
             np.asanyarray(returns),
             np.asanyarray(required_return),
         ),
-        np.NINF,
+        -np.inf,
         0,
     )
 


### PR DESCRIPTION
also added src to pytest ini so one can run it from parent directory.

