### PR TITLE
Fix typo in documentation & restrict sphinx dependency version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ conda/recipe/win-64/
 docs/test/
 admin
 src/empyrical/_version.py
+venv/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_path = pydata_sphinx_theme.get_html_theme_path()
 
 html_theme_options = {
-    "github_url": "https://github.com/stefan-jansen/emyrical-reloaded",
+    "github_url": "https://github.com/stefan-jansen/empyrical-reloaded",
     "twitter_url": "https://twitter.com/ml4trading",
     "external_links": [
         {"name": "ML for Trading", "url": "https://ml4trading.io"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,13 @@ doc = [
     "Sphinx >=1.3.2",
     "numpydoc >=0.5.0",
     "sphinx-autobuild >=0.6.0",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme<0.8.0",
     "sphinx-markdown-tables",
     "sphinx_copybutton",
     "nbsphinx",
-    "m2r2"
+    "m2r2",
+    "lxml-html-clean"
+
 ]
 
 yfinance = [


### PR DESCRIPTION
This PR corrects a documentation typo and updates dependencies to ensure successful documentation builds.

It pins the `pydata-sphinx-theme` dependency to `<v0.8.0` due to the deprecation of `pydata_sphinx_theme.get_html_theme_path()` in later versions.

It adds `lxml-html-clean` as a dependency, as the associated module lxml.html.clean is no longer bundled with `lxml`.