### PR TITLE
Adapt to new pandas/scipy versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pandas>=2.2.2; python_version>='3.12'",
     "bottleneck>=1.3.0",
     "scipy>=0.15.1",
+    "pandas>=1.5.0",
     "peewee"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,11 @@ dependencies = [
     # following pandas
     "numpy>=1.23.5; python_version<'3.12'",
     "numpy>=1.26.0; python_version>='3.12'",
-    #    "numpy>=2.0; python_version>='3.12'",
-    "pandas >=1.5.0; python_version<'3.12'",
+    "pandas>=1.5.0; python_version<'3.12'",
     "pandas>=2.2.2; python_version>='3.12'",
-    "bottleneck >=1.3.0",
-    "pandas >=1.5.0",
-    "scipy >=0.15.1",
-    "peewee<3.17.4" # awwaiting bugfix in latest version: https://github.com/coleifer/peewee/issues/2891
+    "bottleneck>=1.3.0",
+    "scipy>=0.15.1",
+    "peewee"
 ]
 
 [project.urls]

--- a/src/empyrical/perf_attrib.py
+++ b/src/empyrical/perf_attrib.py
@@ -120,7 +120,7 @@ def perf_attrib(returns, positions, factor_returns, factor_loadings):
 
     return (
         risk_exposures_portfolio,
-        pd.concat([perf_attrib_by_factor, returns_df], axis="columns"),
+        pd.concat([perf_attrib_by_factor, returns_df], axis="columns", sort=False),
     )
 
 

--- a/src/empyrical/stats.py
+++ b/src/empyrical/stats.py
@@ -1647,11 +1647,7 @@ def gpd_risk_estimates_aligned(returns, var_p=0.01):
         DEFAULT_THRESHOLD = 0.2
         MINIMUM_THRESHOLD = 0.000000001
 
-        try:
-            returns_array = pd.Series(returns).to_numpy()
-        except AttributeError:
-            # while zipline requires support for pandas < 0.25
-            returns_array = pd.Series(returns).as_matrix()
+        returns_array = pd.Series(returns).to_numpy()
 
         flipped_returns = -1 * returns_array
         losses = flipped_returns[flipped_returns > 0]

--- a/src/empyrical/utils.py
+++ b/src/empyrical/utils.py
@@ -175,18 +175,18 @@ def _roll_ndarray(func, window, *args, **kwargs):
 
 
 def _roll_pandas(func, window, *args, **kwargs):
-    data = {}
-    index_values = []
+    data = []
     for i in range(window, len(args[0]) + 1):
         rets = [s.iloc[i - window : i] for s in args]
-        index_value = args[0].index[i - 1]
-        index_values.append(index_value)
-        data[index_value] = func(*rets, **kwargs)
-    return pd.Series(
-        data,
-        index=type(args[0].index)(index_values),
-        dtype=np.float64,
-    )
+        data.append(func(*rets, **kwargs))
+
+    # Preserve index metadata (dtype/freq/tz) for empty and non-empty results.
+    if len(args[0]) >= window:
+        index = args[0].index[window - 1 :]
+    else:
+        index = args[0].index[:0]
+
+    return pd.Series(data, index=index, dtype=np.float64)
 
 
 def cache_dir(environ=environ):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -21,6 +21,17 @@ DECIMAL_PLACES = 8
 rand = np.random.RandomState(1337)
 
 
+def _linregress_small_sample_warns():
+    small_sample_warning = getattr(stats, "SmallSampleWarning", RuntimeWarning)
+    return pytest.warns(
+        (small_sample_warning, RuntimeWarning),
+        match=(
+            r"invalid value encountered in (?:scalar divide|sqrt)|"
+            r"One or more sample arguments is too small; all returned values will be NaN"
+        ),
+    )
+
+
 class BaseTestClass:
     def assert_indexes_match(self, result, expected):
         """
@@ -809,10 +820,7 @@ class TestStats(BaseTestClass):
             masked_returns_data = returns_arr[mask]
 
             if len(masked_benchmark_data) < 2:
-                with pytest.warns(
-                    RuntimeWarning,
-                    match="invalid value encountered in (?:scalar divide|sqrt)",
-                ):
+                with _linregress_small_sample_warns():
                     slope, intercept, _, _, _ = stats.linregress(
                         masked_benchmark_data, masked_returns_data
                     )
@@ -984,10 +992,7 @@ class TestStats(BaseTestClass):
             masked_returns_data = returns_arr[mask]
 
             if len(masked_benchmark_data) < 2:
-                with pytest.warns(
-                    RuntimeWarning,
-                    match="invalid value encountered in (?:scalar divide|sqrt)",
-                ):
+                with _linregress_small_sample_warns():
                     slope, intercept, _, _, _ = stats.linregress(
                         masked_benchmark_data, masked_returns_data
                     )
@@ -1035,10 +1040,7 @@ class TestStats(BaseTestClass):
             masked_benchmark_data_for_y = benchmark_arr[mask]
 
             if len(masked_returns_data_for_x) < 2:
-                with pytest.warns(
-                    RuntimeWarning,
-                    match="invalid value encountered in (?:scalar divide|sqrt)",
-                ):
+                with _linregress_small_sample_warns():
                     slope, intercept, _, _, _ = stats.linregress(
                         masked_returns_data_for_x, masked_benchmark_data_for_y
                     )


### PR DESCRIPTION
1. remove unnecessary version constraints on dependencies.
 - peewee installation version has been fixed
2. adapt for pandas 3.x
3. fix sicpy warning mismatch for scipy 1.14+